### PR TITLE
Fix markdown headings being truncated in resumed chat history (#12)

### DIFF
--- a/nova/core/chat.py
+++ b/nova/core/chat.py
@@ -102,8 +102,7 @@ class ChatSession:
         print()
 
         for msg in self.conversation.messages:
-            timestamp = msg.timestamp.strftime("%H:%M:%S")
-            print_message(msg.role.value, msg.content, timestamp)
+            print_message(msg.role.value, msg.content)
 
 
 class ChatManager:


### PR DESCRIPTION
## Summary
- Fixes issue #12 where markdown content (especially headings) was being truncated when resuming chat sessions
- Improves message header detection to be more precise and avoid false positives
- Makes resumed chat display consistent with active chat sessions

## Changes Made
- **Enhanced message header parsing**: Updated regex pattern in `nova/core/history.py` to only match exact message headers like "## User (12:34:56)" rather than any line starting with "## "
- **Preserved markdown content**: Modified content filtering to only exclude metadata comments, allowing markdown headings and other formatting to be preserved
- **Consistent display**: Removed timestamp display in conversation history for consistency between resumed and active chats
- **Comprehensive testing**: Added test to verify markdown content preservation during save/load cycles

## Test Plan
- [x] Added specific test for markdown headings preservation
- [x] Verified all existing history tests still pass
- [x] Code passes linting and formatting checks
- [x] Manual testing shows full markdown content is now preserved in resumed chats

## Before/After
**Before**: Resumed chats showed truncated content, cutting off at markdown headings
**After**: Resumed chats display complete conversation history with all markdown formatting preserved

🤖 Generated with [Claude Code](https://claude.ai/code)