### PR TITLE
Fix long message importance weighting

### DIFF
--- a/nova/core/memory.py
+++ b/nova/core/memory.py
@@ -157,10 +157,10 @@ class MemoryManager:
 
         # Boost importance for longer messages (more detailed)
         word_count = len(message.content.split())
-        if word_count > 50:
-            importance_score += 0.2
-        elif word_count > 100:
+        if word_count > 100:
             importance_score += 0.4
+        elif word_count > 50:
+            importance_score += 0.2
 
         # Boost importance for messages with code or technical content
         if any(

--- a/tests/unit/test_memory.py
+++ b/tests/unit/test_memory.py
@@ -127,6 +127,26 @@ class TestMemoryManager:
         )
         assert score > 1.0  # Base score + recency boost
 
+    def test_analyze_message_importance_long_message(self):
+        """Longer messages should yield higher importance scores"""
+        medium_msg = Message(
+            role=MessageRole.USER,
+            content=" ".join(["word"] * 60),  # 60 words
+        )
+        long_msg = Message(
+            role=MessageRole.USER,
+            content=" ".join(["word"] * 120),  # 120 words
+        )
+
+        medium_score = self.memory_manager.analyze_message_importance(
+            medium_msg, self.conversation
+        )
+        long_score = self.memory_manager.analyze_message_importance(
+            long_msg, self.conversation
+        )
+
+        assert long_score > medium_score
+
     def test_optimize_conversation_context(self):
         """Test context optimization"""
         result = self.memory_manager.optimize_conversation_context(self.conversation)


### PR DESCRIPTION
## Summary
- correct ordering of word-count thresholds in `MemoryManager.analyze_message_importance`
- add regression test ensuring long messages receive higher importance scores

## Testing
- `uv run pre-commit run --files nova/core/memory.py tests/unit/test_memory.py` *(fails: unable to fetch pre-commit hooks)*
- `uv run pytest tests/unit/test_memory.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6897a74f3dec8331be24cbf760803bbc